### PR TITLE
Adding reproducibility workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM nvidia/cuda:11.2.0-devel-ubuntu18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update  -y --fix-missing && \
+    apt-get install -y --no-install-recommends \
+    software-properties-common \
+    wget \
+    curl \
+    unrar \
+    unzip \
+    git && \
+    apt-get upgrade -y libstdc++6 && \
+    apt-get clean -y
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y gcc-9 && \
+    apt-get upgrade -y libstdc++6
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b  && \
+    rm -rf Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH=/miniconda/bin:${PATH}
+RUN conda update -y conda
+
+RUN conda install -n base -c conda-forge mamba
+
+ADD ./environment.yml ./environment.yml
+RUN mamba env update -n base -f ./environment.yml && \
+    conda clean -afy
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+IMAGE := autoformer
+ROOT := $(shell dirname $(realpath $(firstword ${MAKEFILE_LIST})))
+
+DOCKER_PARAMETERS := \
+	--user $(shell id -u) \
+	--gpus all \
+	-v ${ROOT}:/app \
+	-w /app \
+	-e HOME=/tmp
+
+init:
+	docker build -t ${IMAGE} .
+
+get_dataset:
+	mkdir -p dataset/ && \
+		make run_module module="python -m utils.download_data" && \
+		unzip dataset/datasets.zip -d dataset/ && \
+		mv dataset/all_six_datasets/* dataset && \
+		rm -r dataset/all_six_datasets dataset/__MACOSX 
+
+run_module: .require-module
+	docker run -i --rm ${DOCKER_PARAMETERS} \
+		${IMAGE} ${module}
+
+bash_docker:
+	docker run -it --rm ${DOCKER_PARAMETERS} ${IMAGE}
+
+.require-module:
+ifndef module
+	$(error module is required)
+endif

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ bash ./scripts/Traffic_script/Autoformer.sh
 bash ./scripts/Weather_script/Autoformer.sh
 bash ./scripts/ILI_script/Autoformer.sh
 ```
+### Reproducibility
+
+To easily reproduce the results using Docker, conda and Make,  you can follow the next steps:
+1. Initialize the docker image using: `make init`. 
+2. Download the datasets using: `make get_dataset`.
+3. Run each script in `scripts/` using `make run_module module="bash scripts/ETT_script/Autoformer_ETTm1.sh"` for each script.
+4. Alternatively, run all the scripts at once:
+```
+for file in `ls scripts`; do make run_module module="bash scripts/$script"; done
+```
 
 4. Sepcial-designed implementation
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: autoformer
+channels:
+  - conda-forge
+  - pytorch
+  - defaults
+dependencies:
+  - python=3.7
+  - pip
+  - matplotlib
+  - numpy
+  - pandas
+  - scikit-learn
+  - pip:
+    - torch==1.9.0

--- a/models/Autoformer.py
+++ b/models/Autoformer.py
@@ -78,7 +78,7 @@ class Model(nn.Module):
                 enc_self_mask=None, dec_self_mask=None, dec_enc_mask=None):
         # decomp init
         mean = torch.mean(x_enc, dim=1).unsqueeze(1).repeat(1, self.pred_len, 1)
-        zeros = torch.zeros([x_dec.shape[0], self.pred_len, x_dec.shape[2]]).cuda()
+        zeros = torch.zeros([x_dec.shape[0], self.pred_len, x_dec.shape[2]], device=x_enc.device)
         seasonal_init, trend_init = self.decomp(x_enc)
         # decoder input
         trend_init = torch.cat([trend_init[:, -self.label_len:, :], mean], dim=1)

--- a/utils/download_data.py
+++ b/utils/download_data.py
@@ -1,0 +1,9 @@
+import requests
+
+if __name__=="__main__":
+    source_url = 'https://cloud.tsinghua.edu.cn/d/e1ccfff39ad541908bae/files/?p=%2Fall_six_datasets.zip&dl=1'
+    headers = {'User-Agent': 'Mozilla/5.0'}
+    res = requests.get(source_url, headers=headers)
+
+    with open('dataset/datasets.zip', 'wb') as f:
+        f.write(res.content)


### PR DESCRIPTION
Hi,

Thanks for your excellent work.
I've added some functionality to reproduce the results quickly:

- A `Dockerfile` to run experiments in a container with gpu functionality.
- An `environment.yml` containing the needed python libraries. Docker creates the image based on this file.
- A `Makefile` to reproduce the results. So you only need to run:
1. `make init`. This will build the Docker image.
2. `make get_dataset`. This will download the datasets.
3. `make run_module module="bash scripts/ETT_script/Autoformer_ETTm1.sh"`. This will run the experiment in the Docker container.

Finally, I've updated the `README.md` with these instructions.

In addition, I included `device` instead of `.cuda()` in  099946198f27125b25d6fefe285befcc0210a8ff; this change will prevent errors when using cpu only. 
