### PR TITLE
Update AutoCorrelation.py

### DIFF
--- a/layers/AutoCorrelation.py
+++ b/layers/AutoCorrelation.py
@@ -57,7 +57,8 @@ class AutoCorrelation(nn.Module):
         channel = values.shape[2]
         length = values.shape[3]
         # index init
-        init_index = torch.arange(length).unsqueeze(0).unsqueeze(0).unsqueeze(0).repeat(batch, head, channel, 1).cuda()
+        init_index = torch.arange(length).unsqueeze(0).unsqueeze(0).unsqueeze(0)\
+            .repeat(batch, head, channel, 1).to(values.device)
         # find top k
         top_k = int(self.factor * math.log(length))
         mean_value = torch.mean(torch.mean(corr, dim=1), dim=1)
@@ -83,7 +84,8 @@ class AutoCorrelation(nn.Module):
         channel = values.shape[2]
         length = values.shape[3]
         # index init
-        init_index = torch.arange(length).unsqueeze(0).unsqueeze(0).unsqueeze(0).repeat(batch, head, channel, 1).cuda()
+        init_index = torch.arange(length).unsqueeze(0).unsqueeze(0).unsqueeze(0)\
+            .repeat(batch, head, channel, 1).to(values.device)
         # find top k
         top_k = int(self.factor * math.log(length))
         weights, delay = torch.topk(corr, top_k, dim=-1)


### PR DESCRIPTION
Fixes issue #63 where the training/inference crash when running on cpu due to the direct use of `cuda()`. Instead use `.to(values.device)` to automatically infer if cpu or gpu should be used. Tried on both gpu and cpu and seems to be working fine.