### PR TITLE
Correct parameters in the Traffic Scripts Reformer.sh and Transformer.sh

### DIFF
--- a/scripts/Traffic_script/Reformer.sh
+++ b/scripts/Traffic_script/Reformer.sh
@@ -14,9 +14,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -35,9 +35,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -56,9 +56,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -77,9 +77,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3

--- a/scripts/Traffic_script/Transformer.sh
+++ b/scripts/Traffic_script/Transformer.sh
@@ -14,9 +14,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -35,9 +35,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -56,9 +56,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3
@@ -77,9 +77,9 @@ python -u run.py \
   --e_layers 2 \
   --d_layers 1 \
   --factor 3 \
-  --enc_in 1 \
-  --dec_in 1 \
-  --c_out 1 \
+  --enc_in 862 \
+  --dec_in 862 \
+  --c_out 862 \
   --des 'Exp' \
   --itr 1 \
   --train_epochs 3


### PR DESCRIPTION
To fix the following error when trying to reproduce training for the provided traffic dataset:

```
RuntimeError: Given groups=1, weight of size [512, 1, 3], expected input[32, 862, 98] to have 1 channels, but got 862 channels instead
```