### PR TITLE
Update Autoformer ETTm1.sh script with --freq 't'

### DIFF
--- a/scripts/ETT_script/Autoformer_ETTm1.sh
+++ b/scripts/ETT_script/Autoformer_ETTm1.sh
@@ -19,6 +19,7 @@ python -u run.py \
   --dec_in 7 \
   --c_out 7 \
   --des 'Exp' \
+  --freq 't' \
   --itr 1
 
 python -u run.py \
@@ -39,6 +40,7 @@ python -u run.py \
   --dec_in 7 \
   --c_out 7 \
   --des 'Exp' \
+  --freq 't' \
   --itr 1
 
 python -u run.py \
@@ -59,6 +61,7 @@ python -u run.py \
   --dec_in 7 \
   --c_out 7 \
   --des 'Exp' \
+  --freq 't' \
   --itr 1
 
 python -u run.py \
@@ -79,6 +82,7 @@ python -u run.py \
   --dec_in 7 \
   --c_out 7 \
   --des 'Exp' \
+  --freq 't' \
   --itr 1
 
 python -u run.py \
@@ -99,4 +103,5 @@ python -u run.py \
   --dec_in 7 \
   --c_out 7 \
   --des 'Exp' \
+  --freq 't' \
   --itr 1


### PR DESCRIPTION
While the Dataset_ETT_minute(Dataset) has as default 'h' in the freq argument in the class constructor,when  I execute the ETTm1 script the freq argument is overridden with the default which is --freq 'h' and if I am not wrong it is also passed to the __init__ of the class Dataset_ETT_minute(Dataset). Am I wrong?