### PR TITLE
change sklearn to scikit-learn in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-sklearn
+scikit-learn
 torchvision
 numpy
 matplotlib


### PR DESCRIPTION
Thank you for the great repository and paper.

Small mistake in the requirments, should be `scikit-learn` 

Ref: https://stackoverflow.com/questions/38733220/difference-between-scikit-learn-and-sklearn-now-deprecated

Eli 

